### PR TITLE
feat: SEOキーワード強化（title・description・h1/h2に具体的な航路名追加）

### DIFF
--- a/ship_info/templates/base.html.twig
+++ b/ship_info/templates/base.html.twig
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}フェリー運航情報サービス{% endblock %}</title>
-    {%- set page_description -%}{%- block description_text -%}フェリーの運航情報を提供するサービスです。{%- endblock -%}{%- endset -%}
+    <title>{% block title %}フェリー運航情報サービス{% endblock %}{% block title_suffix %} | 鹿児島〜沖縄フェリー運航状況{% endblock %}</title>
+    {%- set page_description -%}{%- block description_text -%}鹿児島〜沖縄・奄美大島を結ぶAライン・マリックスラインのリアルタイム運航状況。欠航・遅延・通常運航を毎時更新でお知らせします。{%- endblock -%}{%- endset -%}
     <meta name="description" content="{{ page_description }}">
     {% set canonical_url = app.request.schemeAndHttpHost ~ app.request.pathInfo %}
     <link rel="canonical" href="{{ canonical_url }}">
@@ -12,7 +12,7 @@
     <meta property="og:description" content="{{ page_description }}">
     <meta property="og:url" content="{{ canonical_url }}">
     <meta property="og:type" content="website">
-    <meta property="og:site_name" content="フェリー運航情報サービス">
+    <meta property="og:site_name" content="鹿児島〜沖縄フェリー運航情報サービス">
     <meta name="twitter:card" content="summary">
     <link rel="stylesheet" href="{{ asset('/css/styles.css') }}">
     {% if app.environment == 'prod' and ga_measurement_id %}
@@ -28,7 +28,7 @@
 </head>
 <body>
     <header>
-        <h1>フェリー運航情報サービス</h1>
+        <h1>鹿児島〜沖縄・奄美大島 フェリー運航情報</h1>
         <nav>
             <ul>
                 <li><a href="{{ path('app_home') }}">ホーム</a></li>
@@ -43,7 +43,7 @@
     </main>
 
     <footer>
-        <p>&copy; 2025 フェリー運航情報サービス</p>
+        <p>&copy; 2025 鹿児島〜沖縄・奄美大島 フェリー運航情報サービス</p>
     </footer>
 </body>
 </html>

--- a/ship_info/templates/details/index.html.twig
+++ b/ship_info/templates/details/index.html.twig
@@ -1,12 +1,13 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}今日の運航情報{% endblock %}
-{% block description_text %}今日のフェリー運航情報です。航路ごとの出発・到着時刻や運航ステータスを確認できます。{% endblock %}
+{% block title %}今日のフェリー運航スケジュール・欠航情報{% endblock %}
+{% block title_suffix %}{% endblock %}
+{% block description_text %}本日のAライン・マリックスラインの出発・到着時刻と運航ステータス。欠航・遅延が発生している航路をひと目で確認。鹿児島〜那覇・鹿児島〜奄美大島の当日スケジュール。{% endblock %}
 
 {% block body %}
 <main>
     <section id="operations-today">
-        <h2>今日の運航情報</h2>
+        <h2>今日のフェリー運航スケジュール・欠航情報</h2>
 
         {% if companies is not empty %}
             {% for company in companies %}

--- a/ship_info/templates/home/index.html.twig
+++ b/ship_info/templates/home/index.html.twig
@@ -1,12 +1,13 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}フェリー運航情報{% endblock %}
-{% block description_text %}フェリーの現在の運航状況を確認できます。欠航情報をいち早くお知らせします。{% endblock %}
+{% block title %}鹿児島〜沖縄・奄美大島フェリー運航情報{% endblock %}
+{% block title_suffix %}{% endblock %}
+{% block description_text %}Aライン・マリックスラインの鹿児島〜那覇・奄美大島間フェリーの最新運航状況。欠航・遅延情報を毎時更新。旅行前に出発港・到着港の運航状況をご確認ください。{% endblock %}
 
 {% block body %}
 <main>
     <section id="home">
-        <h2>現在の運航状況</h2>
+        <h2>現在の運航状況（Aライン・マリックスライン）</h2>
         {% if ship_data is not empty %}
             {% for ship in ship_data %}
             <div class="ferry-status">

--- a/ship_info/tests/DetailsControllerTest.php
+++ b/ship_info/tests/DetailsControllerTest.php
@@ -22,7 +22,7 @@ class DetailsControllerTest extends IntegrationTestCase
         $client = static::createClient();
         $this->mockClock('2025-02-12');
         $client->request('GET', '/details/today');
-        $this->assertSelectorTextContains('h2', '今日の運航情報');
+        $this->assertSelectorTextContains('h2', '今日のフェリー運航スケジュール・欠航情報');
     }
 
     public function testDetailsPageShowsNoDataMessageWhenEmpty(): void
@@ -89,8 +89,8 @@ class DetailsControllerTest extends IntegrationTestCase
             $this->assertResponseIsSuccessful();
             // 今日の運航が描画されていることをステータステキストで確認
             $this->assertStringContainsString('通常運航', $content);
-            // 前日の便（欠航）はフィルタで除外される
-            $this->assertStringNotContainsString('欠航', $content);
+            // 前日の便（欠航・09:00発）はフィルタで除外される
+            $this->assertStringNotContainsString('09:00', $content);
         } finally {
             $this->cleanupEntity($em, Company::class, $companyId);
         }


### PR DESCRIPTION
## Summary

- `base.html.twig`: titleサフィックス追加、デフォルトdescription・h1・og:site_nameに「鹿児島〜沖縄・奄美大島」を明示
- `home/index.html.twig`: title・description・h2に「Aライン・マリックスライン」「欠航」「遅延」などの検索キーワードを追加
- `details/index.html.twig`: title・description・h2に「欠航情報」「スケジュール」キーワードを追加
- `DetailsControllerTest`: 変更後のh2テキストに合わせてテスト更新（欠航フィルタ確認も時刻ベースに改善）

## Test plan

- [x] `php bin/phpunit` 11/11 グリーン確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)